### PR TITLE
feat(format): round options as boolean

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ yarn add gen-unit
     - `round` [option as an object](#round-option-as-an-object)
     - `round` [option as a number](#round-option-as-a-number)
     - `round` [option as a function](#round-option-as-a-function)
+    - `round` [option as a boolean](#round-option-as-a-boolean)
   - `output` [option](#the-output-option)
     - `output` [option as an object](#output-option-as-an-object)
     - `output` [option as a function](#output-option-as-a-function)
@@ -572,6 +573,57 @@ format(1.23); // => '1'
 format(1.75); // => '2'
 format(1230); // => '1 k'
 format(0.00123); // => '1 m'
+```
+
+##### `round` option as a boolean
+
+```typescript
+round: boolean;
+```
+
+A `boolean` defining wether or not to round the number. If `true` is passed, the default rounder will be used (2 decimals). If `false` is passed, rounding will be disabled.
+
+***Example***
+
+```typescript
+const format = createFormatter({
+  round: true,
+});
+
+format(1.231); // => '1.23'
+format(1.238); // => '1.24'
+format(1200); // => '1.2 k'
+format(0.001234); // => '1.23 m'
+```
+
+```typescript
+const format = createFormatter({
+  round: false,
+});
+
+format(1.234); // => '1.234'
+format(1.28); // => '1.28'
+format(1233); // => '1.233 k'
+format(0.0012); // => '1.2 m'
+```
+
+Keep in mind disabling the rounder will case the the output to receive the value in it's raw form and you might get unpredictable results, see example...
+
+***Example***
+
+```typescript
+const format = createFormatter({});
+const formatWithoutRounding = createFormatter({ round: false });
+
+const pointThree = 0.1 + 0.2; // in javascript 0.1 + 0.2 = 0.30000000000000004
+
+format(pointThree); // => '0.3'
+formatWithoutRounding(pointThree); // => '0.30000000000000004'
+
+const threeThousand = pointThree * 10000; // 3000.0000000000005
+
+format(threeThousand); // => '3 k'
+formatWithoutRounding(threeThousand); // => '3000.0000000000005 k'
 ```
 
 #### The `output` option

--- a/__test__/format/options/round-option.test.ts
+++ b/__test__/format/options/round-option.test.ts
@@ -7,8 +7,6 @@ describe('formatter "round" option', () => {
     const values = [
       '',
       'string',
-      true,
-      false,
     ]
 
     values.forEach((invalid) => {
@@ -174,6 +172,42 @@ describe('formatter "round" option', () => {
 
       values.forEach(({ value, dec, expected }) => {
         const format = createFormatter({ round: { dec, fixed: true } })
+        expect(format(value)).toBe(expected)
+      })
+
+    })
+
+  })
+
+  describe('"round" option as boolean', () => {
+
+    test('Should not round if false passed', () => {
+
+      const values = [
+        10.1111111,
+        12.1,
+        12,
+      ]
+
+      const format = createFormatter({ round: false })
+
+      values.forEach((value) => {
+        expect(format(value)).toBe(`${value}`)
+      })
+
+    })
+
+    test('Should use default 2 decimal places if true passed', () => {
+
+      const values = [
+        { value: 10.1111111, expected: '10.11' },
+        { value: 12.1, expected: '12.1' },
+        { value: 12, expected: '12' },
+      ]
+
+      const format = createFormatter({ round: true })
+
+      values.forEach(({ value, expected }) => {
         expect(format(value)).toBe(expected)
       })
 

--- a/src/format/round.ts
+++ b/src/format/round.ts
@@ -33,7 +33,7 @@ export function createRounderFromOptions(dec: number, fixed?: AllowNullish<boole
 export function createRounder(round: FormatRoundOption): RoundFunction {
 
   // return default rounder if round option is nullish
-  if (isNullish(round)) return createRounderFromOptions(2)
+  if (isNullish(round) || round === true) return createRounderFromOptions(2)
 
   // return user option if it's a function
   if (isFunction(round)) return round
@@ -42,6 +42,8 @@ export function createRounder(round: FormatRoundOption): RoundFunction {
   if (isNumber(round)) return createRounderFromOptions(
     validateNumberOfDecimals(round),
   )
+
+  if (round === false) return (n) => n
 
   // throw if round option is not an object at this point
   if (!isObject(round)) throw errorInvalidOption('round')

--- a/src/format/types.ts
+++ b/src/format/types.ts
@@ -15,7 +15,7 @@ export interface FormatRoundAdvancedOptions {
   readonly dec?: AllowNullish<RoundDecimals>
   readonly fixed?: AllowNullish<boolean>
 }
-export type FormatRoundOption = AllowNullish<RoundDecimals | FormatRoundAdvancedOptions | RoundFunction>
+export type FormatRoundOption = AllowNullish<RoundDecimals | FormatRoundAdvancedOptions | RoundFunction | boolean>
 
 export type FormatOutputFunction<U extends string = string> = (value: string | number, pre: string, unit: U) => string
 export interface FormatOutputAdvancedOption {


### PR DESCRIPTION
`createFormatter` `round` option can be passes as a `boolean` value. If `true` is passed, the default rounder will be used (2 decimals). If `false` is passed, rounding will be disabled.