### PR TITLE
fix: Update types for better intellisense

### DIFF
--- a/__test__/common/validate-option.test.ts
+++ b/__test__/common/validate-option.test.ts
@@ -1,6 +1,6 @@
 import { validateOptions } from '../../src/common/validate-options'
 
-describe('invalid options', () => {
+describe('validateOptions function', () => {
 
   const validate = (options: Record<string, unknown>) => validateOptions(
     options,
@@ -9,13 +9,13 @@ describe('invalid options', () => {
   )
 
   test('Should throw if removed option used', () => {
-    const unknownOptions = [
+    const removedOptions = [
       'removedOne',
       'removedTwo',
     ]
-    unknownOptions.forEach((optionName) => {
-      const callCreateFormatterWithUnknownOption = () => validate({ [optionName]: null })
-      expect(callCreateFormatterWithUnknownOption).toThrow(`Option "${optionName}" has been removed`)
+    removedOptions.forEach((removedOptionName) => {
+      const callValidateWithRemovedOption = () => validate({ [removedOptionName]: null })
+      expect(callValidateWithRemovedOption).toThrow(`Option "${removedOptionName}" has been removed`)
     })
   })
 
@@ -26,9 +26,9 @@ describe('invalid options', () => {
       'any-option',
       'anyOption',
     ]
-    unknownOptions.forEach((optionName) => {
-      const callCreateFormatterWithUnknownOption = () => validate({ [optionName]: null })
-      expect(callCreateFormatterWithUnknownOption).toThrow(`Unknown option "${optionName}"`)
+    unknownOptions.forEach((unknownOptionName) => {
+      const callValidateWithUnknownOption = () => validate({ [unknownOptionName]: null })
+      expect(callValidateWithUnknownOption).toThrow(`Unknown option "${unknownOptionName}"`)
     })
   })
 

--- a/src/common/is.ts
+++ b/src/common/is.ts
@@ -1,6 +1,6 @@
-import type { Nullish, TypeCheckFunction, Void } from './private-types'
+import type { NullishReturn, TypeCheckFunction } from './private-types'
 
-export function isNullish(value: unknown): value is Nullish | Void {
+export function isNullish(value: unknown): value is NullishReturn {
   return value == null
 }
 

--- a/src/common/private-types.ts
+++ b/src/common/private-types.ts
@@ -1,8 +1,18 @@
 // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-export type Void = void
-export type Nullish = null | undefined
+type Void = void
 
-export type AllowVoid<T> = T | Void
+export type Nullish = null | undefined
+export type NullishReturn = Nullish | Void
+
 export type AllowNullish<T> = T | Nullish
+export type AllowNullishReturn<T> = T | NullishReturn
 
 export type TypeCheckFunction<T> = (value: unknown) => value is T
+
+export interface WithUnit<U> {
+  readonly unit: U
+}
+
+export interface WithOptionalFind<F> {
+  readonly find?: F
+}

--- a/src/format/create-formatter.ts
+++ b/src/format/create-formatter.ts
@@ -25,8 +25,8 @@ function deprecated_createGetUnit(unit: FormatUnitOption | DeprecatedFormatGetUn
  *
  * @param options create formatter options
  */
-export function createFormatter<U extends FormatUnitOption>(options: CreateFormatterOptionsWithUnit<U>): Formatter
 export function createFormatter(options: CreateFormatterOptionsWithoutUnit): Formatter
+export function createFormatter<U extends FormatUnitOption>(options: CreateFormatterOptionsWithUnit<U>): Formatter
 export function createFormatter(options?: CreateFormatterOptions): Formatter
 export function createFormatter(options: CreateFormatterOptions = {}): Formatter {
 

--- a/src/format/format.ts
+++ b/src/format/format.ts
@@ -1,8 +1,8 @@
 import { createFormatter } from './create-formatter'
 import type { CreateFormatterOptions, CreateFormatterOptionsWithoutUnit, CreateFormatterOptionsWithUnit, FormatUnitOption } from './types'
 
-export function format<U extends FormatUnitOption>(value: number, options?: CreateFormatterOptionsWithUnit<U>): string
 export function format(value: number, options: CreateFormatterOptionsWithoutUnit): string
+export function format<U extends FormatUnitOption>(value: number, options?: CreateFormatterOptionsWithUnit<U>): string
 export function format(value: number, options?: CreateFormatterOptions): string
 export function format(value: number, options?: CreateFormatterOptions): string {
   const formatter = createFormatter(options)

--- a/src/format/types.ts
+++ b/src/format/types.ts
@@ -1,10 +1,11 @@
-import type { AllowNullish, AllowVoid } from '../common/private-types'
+import type { AllowNullish, AllowNullishReturn, WithOptionalFind, WithUnit } from '../common/private-types'
+import { Nullish } from '../common/private-types'
 import type { DeclarativeFindUnit, MultiplierFindItem } from '../common/types'
 import type { DeprecatedFormatFindUnitFunction, DeprecatedFormatGetUnitFunction } from '../deprecated-types'
 
 export type FormatUnitOption = AllowNullish<string>
 
-export type FormatFindUnitFunction = (value: number) => AllowVoid<AllowNullish<MultiplierFindItem>>
+export type FormatFindUnitFunction = (value: number) => AllowNullishReturn<MultiplierFindItem>
 // eslint-disable-next-line @typescript-eslint/no-deprecated
 export type FormatFindUnitOption = AllowNullish<DeclarativeFindUnit | FormatFindUnitFunction> | DeprecatedFormatFindUnitFunction
 
@@ -23,18 +24,15 @@ export interface FormatOutputAdvancedOption {
 }
 export type FormatOutputOption<U extends string = string> = AllowNullish<FormatOutputFunction<U> | FormatOutputAdvancedOption>
 
-interface CreateFormatterOptionsBase<U extends string> {
-  readonly find?: FormatFindUnitOption
+interface CreateFormatterOptionsBase<U extends string> extends WithOptionalFind<FormatFindUnitOption> {
   readonly round?: FormatRoundOption
   readonly output?: FormatOutputOption<U>
 }
 
-export type CreateFormatterOptionsWithoutUnit = CreateFormatterOptionsBase<string>
+export interface CreateFormatterOptionsWithoutUnit extends Partial<WithUnit<Nullish>>, CreateFormatterOptionsBase<string> {}
 
-export interface CreateFormatterOptionsWithUnit<U extends FormatUnitOption> extends CreateFormatterOptionsBase<U extends string ? U : string> {
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  readonly unit: U | DeprecatedFormatGetUnitFunction<U extends string ? U : string>
-}
+// eslint-disable-next-line @typescript-eslint/no-deprecated
+export interface CreateFormatterOptionsWithUnit<U extends FormatUnitOption> extends WithUnit<U | DeprecatedFormatGetUnitFunction<U extends string ? U : string>>, CreateFormatterOptionsBase<U extends string ? U : string> {}
 
 export type CreateFormatterOptions = Partial<CreateFormatterOptionsWithUnit<FormatUnitOption>>
 

--- a/src/parse/create-parser.ts
+++ b/src/parse/create-parser.ts
@@ -12,8 +12,8 @@ import type { CreateParserOptions, CreateParserOptionsWithoutUnit, CreateParserO
  *
  * @param options create parser options
  */
-export function createParser<U extends ParseUnitOption>(options: CreateParserOptionsWithUnit<U>): Parser
 export function createParser(options: CreateParserOptionsWithoutUnit): Parser
+export function createParser<U extends ParseUnitOption>(options: CreateParserOptionsWithUnit<U>): Parser
 export function createParser(options?: CreateParserOptionsWithUnit<ParseUnitOption> | CreateParserOptionsWithoutUnit): Parser
 export function createParser(options: CreateParserOptionsWithUnit<ParseUnitOption> | CreateParserOptionsWithoutUnit = {}): Parser {
 

--- a/src/parse/parse.ts
+++ b/src/parse/parse.ts
@@ -8,8 +8,8 @@ import type { CreateParserOptionsWithoutUnit, CreateParserOptionsWithUnit, Parse
  * @param options parser options
  * @returns parsed value or NaN if it can't be parsed
  */
-export function parse<U extends ParseUnitOption>(input: ParseInput, options: CreateParserOptionsWithUnit<U>): number
 export function parse(input: ParseInput, options: CreateParserOptionsWithoutUnit): number
+export function parse<U extends ParseUnitOption>(input: ParseInput, options: CreateParserOptionsWithUnit<U>): number
 export function parse(input: ParseInput, options?: CreateParserOptionsWithUnit<ParseUnitOption> | CreateParserOptionsWithoutUnit): number
 export function parse(input: ParseInput, options?: CreateParserOptionsWithUnit<ParseUnitOption> | CreateParserOptionsWithoutUnit): number {
   const parser = createParser(options)

--- a/src/parse/types.ts
+++ b/src/parse/types.ts
@@ -1,27 +1,24 @@
-import type { AllowNullish, AllowVoid } from '../common/private-types'
+import type { AllowNullish, AllowNullishReturn, Nullish, WithOptionalFind, WithUnit } from '../common/private-types'
 import type { DeclarativeFindUnit } from '../common/types'
 
 export type ParseUnitOption = AllowNullish<string>
 
 export type InputMatchResults = [value: string, wholeUnit: string]
-export type MatchFunction = (input: string) => AllowVoid<AllowNullish<InputMatchResults>>
+export type MatchFunction = (input: string) => AllowNullishReturn<InputMatchResults>
 export type RegExpPattern = RegExp | string
 export type ParseMatchOption = AllowNullish<RegExpPattern | MatchFunction>
 
 export type ParseMultiplier = number
-export type ParseFindMultiplierFunction<U extends ParseUnitOption = ParseUnitOption> = (prefix: string, unit: U) => AllowVoid<AllowNullish<ParseMultiplier>>
+export type ParseFindMultiplierFunction<U extends ParseUnitOption = ParseUnitOption> = (prefix: string, unit: U) => AllowNullishReturn<ParseMultiplier>
 export type ParseFindMultiplierOption<U extends ParseUnitOption = ParseUnitOption> = AllowNullish<DeclarativeFindUnit | ParseFindMultiplierFunction<U>>
 
-interface CreateParserOptionsBase<U extends ParseUnitOption> {
+interface CreateParserOptionsBase<U extends ParseUnitOption> extends WithOptionalFind<ParseFindMultiplierOption<U>> {
   readonly match?: ParseMatchOption
-  readonly find?: ParseFindMultiplierOption<U>
 }
 
-export type CreateParserOptionsWithoutUnit = CreateParserOptionsBase<undefined>
+export interface CreateParserOptionsWithoutUnit extends Partial<WithUnit<Nullish>>, CreateParserOptionsBase<undefined> {}
 
-export interface CreateParserOptionsWithUnit<U extends ParseUnitOption> extends CreateParserOptionsBase<U> {
-  readonly unit: U
-}
+export interface CreateParserOptionsWithUnit<U extends ParseUnitOption> extends WithUnit<U>, CreateParserOptionsBase<U> {}
 
 export type CreateParserOptions = Partial<CreateParserOptionsWithUnit<ParseUnitOption>>
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,6 @@
 {
-  "extends": "./tsconfig.base.json",
   "include": [
     "src"
-  ]
+  ],
+  "extends": "./tsconfig.base.json"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
-  "extends": "./tsconfig.base.json",
   "include": [
     "src",
     "__test__"
-  ]
+  ],
+  "extends": "./tsconfig.base.json"
 }


### PR DESCRIPTION
option `unit` is now visible for intellisense in `createFormatter`, `format`, `createParser` and `parse` functions